### PR TITLE
fix bug in print help

### DIFF
--- a/src/sargparse/sargparse.rs
+++ b/src/sargparse/sargparse.rs
@@ -231,12 +231,12 @@ impl ArgumentParser {
         println!("\n");
         println!("Required arguments:");
         for arg in &self.required_args {
-            println!("\t--{} (-{}, {:?}): {}", arg.long_name, arg.short_name, arg.dtype, arg.help);
+            println!("\t{} ({}, {:?}): {}", arg.long_name, arg.short_name, arg.dtype, arg.help);
         }
         println!("\n");
         println!("Optional arguments:");
         for arg in &self.optional_args {
-            println!("\t--{} (-{}, {:?}): {}", arg.long_name, arg.short_name, arg.dtype, arg.help);
+            println!("\t{} ({}, {:?}): {}", arg.long_name, arg.short_name, arg.dtype, arg.help);
         }
     }
 


### PR DESCRIPTION
Hi !, I wanted to fix this bug in the application output in case of failure to pass parameters.
The - are all doubled in the message and this may cause difficulties for the user using the application to pass parameters correctly.
An example in attached photo
![image](https://user-images.githubusercontent.com/26500347/183242345-45b2c2bd-627d-45f3-bdee-a3bb49017667.png)
